### PR TITLE
[ENH] add support for skip-test for jupytext targeting

### DIFF
--- a/sphinxcontrib/tomyst/writers/translator.py
+++ b/sphinxcontrib/tomyst/writers/translator.py
@@ -941,6 +941,8 @@ class MystTranslator(SphinxTranslator):
         :dedent: option cannot be inferred as text is already altered
         but could be a PR upstream in
         sphinx/directives/code.py -> literal['dedent'] = self.options['dedent']
+
+        # TODO: Rework this function to be dict(options)
         """
         attributes = node.attributes
         options = []
@@ -968,6 +970,8 @@ class MystTranslator(SphinxTranslator):
                     options.append("caption: {}".format(caption))
         if node.hasattr("force") and attributes["force"]:
             options.append("force:")
+        if self.target_jupytext and "skip-test" in node.attributes["classes"]:
+            options.append("tags: [raises-exception]")
         options.append("---")
         if len(options) == 2:
             options = []

--- a/tests/snippet/test_snippet.myst
+++ b/tests/snippet/test_snippet.myst
@@ -2,11 +2,25 @@
 snippet.md
 ----------
 
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
 # Snippet
 
 Another snippet test
 
-```{code-block} python3
+```{code-cell} python3
+---
+tags: [raises-exception]
+---
 from random import uniform
 
 samples = [uniform(0, 1) for i in range(10)]

--- a/tests/source/code-blocks-jupytext/test.rst
+++ b/tests/source/code-blocks-jupytext/test.rst
@@ -43,3 +43,10 @@ Test no-execute passthrough to code-blocks
    :class: no-execute
 
    import numpy as np
+
+Test skip-test passthrough to code-cells
+
+.. code-block:: python
+   :class: skip-test
+
+   print(thisfails)

--- a/tests/source/snippet/conf.py
+++ b/tests/source/snippet/conf.py
@@ -1,10 +1,3 @@
 extensions = ["sphinxcontrib.tomyst"]
 exclude_patterns = ["_build"]
-
-tomyst_jupytext_header = """
----
-kernelspec:
-  display_name: Python 3
-  name: python3
----
-"""
+tomyst_jupytext = True

--- a/tests/source/snippet/snippet.rst
+++ b/tests/source/snippet/snippet.rst
@@ -3,15 +3,11 @@ Snippet
 
 Another snippet test
 
-<<<<<<< HEAD
-    ``import numpy as np``
-=======
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     from random import uniform
 
     samples = [uniform(0, 1) for i in range(10)]
     F = ECDF(samples)
     F(0.5)  # Evaluate ecdf at x = 0.5
->>>>>>> master

--- a/tests/test_build/test_multi_language_jupytext.myst
+++ b/tests/test_build/test_multi_language_jupytext.myst
@@ -83,3 +83,12 @@ Test no-execute passthrough to code-blocks
 import numpy as np
 ```
 
+Test skip-test passthrough to code-cells
+
+```{code-cell} python
+---
+tags: [raises-exception]
+---
+print(thisfails)
+```
+

--- a/tests/test_build/test_multi_language_jupytext.xml
+++ b/tests/test_build/test_multi_language_jupytext.xml
@@ -30,3 +30,7 @@
                 Test no-execute passthrough to code-blocks
             <literal_block classes="no-execute" force="False" highlight_args="{}" language="python" xml:space="preserve">
                 import numpy as np
+            <paragraph>
+                Test skip-test passthrough to code-cells
+            <literal_block classes="skip-test" force="False" highlight_args="{}" language="python" xml:space="preserve">
+                print(thisfails)


### PR DESCRIPTION
A code block that uses `:class: skip-test` when targeting `jupytext` will now add `tags: [raises-exception]` to `code-cells`

https://myst-nb.readthedocs.io/en/latest/use/execute.html#dealing-with-code-that-raises-errors