### PR TITLE
[ENH] add support for only directives (sphinx)

### DIFF
--- a/sphinxcontrib/tomyst/writers/myst.py
+++ b/sphinxcontrib/tomyst/writers/myst.py
@@ -66,10 +66,10 @@ class MystSyntax(MarkdownSyntax):
 
     # - Syntax Methods - #
 
-    def visit_directive(self, type, title=None, options=None):
+    def visit_directive(self, type, argument=None, options=None):
         directive = "```{" + "{}".format(type) + "}"
-        if title:
-            directive += " {}".format(title)
+        if argument:
+            directive += " {}".format(argument)
         if options:
             directive += "\n{}".format("\n".join(options))
         return directive

--- a/sphinxcontrib/tomyst/writers/translator.py
+++ b/sphinxcontrib/tomyst/writers/translator.py
@@ -1071,10 +1071,14 @@ class MystTranslator(SphinxTranslator):
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-only
 
     def visit_only(self, node):
-        pass  # TODO: can this be removed in favour of default method
+        target = node.attributes["expr"]
+        self.output.append(self.syntax.visit_directive("only", argument=target))
+        self.add_newline()
 
     def depart_only(self, node):
-        pass
+        self.remove_newline()
+        self.output.append(self.syntax.depart_directive())
+        self.add_newparagraph()
 
     # docutils.elements.option
     # https://docutils.sourceforge.io/docs/ref/doctree.html#option

--- a/tests/snippet/test_snippet.myst
+++ b/tests/snippet/test_snippet.myst
@@ -15,44 +15,13 @@ kernelspec:
 
 # Snippet
 
-Another snippet test
+```{only} html
+HTML
 
-skip-test
-
-```{code-cell} python3
----
-tags: [raises-exception]
----
-from random import uniform
-
-samples = [uniform(0, 1) for i in range(10)]
-F = ECDF(samples)
-F(0.5)  # Evaluate ecdf at x = 0.5
 ```
 
-hide-output
+```{only} latex
+LaTeX
 
-```{code-cell} python3
----
-tags: [hide-output]
----
-from random import uniform
-
-samples = [uniform(0, 1) for i in range(10)]
-F = ECDF(samples)
-F(0.5)  # Evaluate ecdf at x = 0.5
-```
-
-both
-
-```{code-cell} python3
----
-tags: [raises-exception, hide-output]
----
-from random import uniform
-
-samples = [uniform(0, 1) for i in range(10)]
-F = ECDF(samples)
-F(0.5)  # Evaluate ecdf at x = 0.5
 ```
 

--- a/tests/source/sphinx/conf.py
+++ b/tests/source/sphinx/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinxcontrib.tomyst"]
+exclude_patterns = ["_build"]
+tomyst_parser = "myst_parser"

--- a/tests/source/sphinx/directives.rst
+++ b/tests/source/sphinx/directives.rst
@@ -1,5 +1,10 @@
-Snippet
-=======
+Directives
+==========
+
+only
+----
+
+The only directive
 
 .. only:: html
 

--- a/tests/source/sphinx/index.rst
+++ b/tests/source/sphinx/index.rst
@@ -1,0 +1,8 @@
+Sphinx Tests
+============
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   directives

--- a/tests/test_mystparser.py
+++ b/tests/test_mystparser.py
@@ -79,6 +79,32 @@ def test_extended(
 
 
 @pytest.mark.sphinx(
+    buildername="myst", srcdir=os.path.join(SOURCE_DIR, "sphinx"), freshenv=True
+)
+def test_sphinx(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    get_sphinx_app_output,
+    remove_sphinx_builds,
+):
+    """basic test."""
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+
+    # Note: pytest needs to run twice to initialise fixtures
+
+    get_sphinx_app_doctree(app, docname="directives", regress=True)
+    get_sphinx_app_output(
+        app,
+        files=["index.md", "directives.md"],
+        regress=True,
+    )
+
+
+@pytest.mark.sphinx(
     buildername="myst", srcdir=os.path.join(SOURCE_DIR, "code-blocks"), freshenv=True
 )
 def test_multi_language(

--- a/tests/test_mystparser/test_sphinx.myst
+++ b/tests/test_mystparser/test_sphinx.myst
@@ -1,0 +1,56 @@
+--------
+index.md
+--------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Sphinx Tests
+
+```{toctree}
+---
+caption: Contents:
+maxdepth: 2
+---
+
+directives
+```
+
+
+-------------
+directives.md
+-------------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Directives
+
+## only
+
+The only directive
+
+```{only} html
+HTML
+```
+
+```{only} latex
+LaTeX
+```
+

--- a/tests/test_mystparser/test_sphinx.xml
+++ b/tests/test_mystparser/test_sphinx.xml
@@ -1,0 +1,15 @@
+<document source="directives.rst">
+    <section ids="directives" names="directives">
+        <title>
+            Directives
+        <section ids="only" names="only">
+            <title>
+                only
+            <paragraph>
+                The only directive
+            <only expr="html">
+                <paragraph>
+                    HTML
+            <only expr="latex">
+                <paragraph>
+                    LaTeX


### PR DESCRIPTION
This PR adds support to transfer `only` directives in source `RST`

```rst
.. only:: html

   <html>
```

get's transferred to

````md
```{only} html
<html>
```
````