### PR TITLE
[ENH] fix footnote references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          pip install sphinx-book-theme myst-nb jupyter_client
+          pip install sphinx-book-theme myst-nb jupyter-client
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          pip install sphinx-book-theme myst-nb jupyter-client
+          pip install sphinx-book-theme myst-nb
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list
@@ -34,14 +34,12 @@ jobs:
       - name: Build https://github.com/QuantEcon/lecture-python-programming
         shell: bash -l {0}
         run: |
-          pwd
           cd lecture-python-programming
           git checkout sphinxcontrib-tomyst
           make myst
       - name: Build Myst Version
         shell: bash -l {0}
         run: |
-          pwd
           cd lecture-python-programming/_build/myst/
           make html
       - name: Preview Deploy to Netlify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install sphinx-book-theme myst-nb
+          pip install -U jupyter-client
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -l {0}
         run: |
-          pip install sphinx-book-theme myst-nb
+          pip install sphinx-book-theme myst-nb jupyter_client
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/sphinxcontrib/tomyst/writers/myst.py
+++ b/sphinxcontrib/tomyst/writers/myst.py
@@ -58,6 +58,18 @@ class MystSyntax(MarkdownSyntax):
     def depart_figure(self):
         return "```"
 
+    def visit_footnote(self, refname):
+        return "[^{}]: ".format(refname)
+
+    def depart_footnote(self):
+        pass
+
+    def visit_footnote_reference(self, refname):
+        return "[^{}]".format(refname)
+
+    def depart_footnote_reference(self):
+        pass
+
     def visit_raw(self, rawformat):
         return "```{{raw}} {}".format(rawformat)
 

--- a/tests/snippet/test_snippet.myst
+++ b/tests/snippet/test_snippet.myst
@@ -15,13 +15,26 @@ kernelspec:
 
 # Snippet
 
-```{only} html
-HTML
+Add a footnote
 
-```
+Lorem ipsum [^f1] dolor sit amet ... [^f2]
 
-```{only} latex
-LaTeX
+[^f1]: Text of the first footnote.
 
-```
+[^f2]: Text of the second footnote.
+
+Lorem ipsum [^autoid_0] dolor sit amet ... [^autoid_1]
+
+[^autoid_0]: Text of the first footnote.
+
+[^autoid_1]: Text of the second footnote.
+
+and example from lectures
+
+Just as [NumPy](http://www.numpy.org/) provides the basic array data type plus core array operations, pandas
+
+1. endows them with methods that facilitate operations such as
+    * sorting, grouping, re-ordering and general data munging [^mung]
+
+[^mung]: Wikipedia defines munging as cleaning data from one raw form into a structured, purged one.
 

--- a/tests/source/docutils/footnotes.rst
+++ b/tests/source/docutils/footnotes.rst
@@ -1,7 +1,10 @@
-Snippet
-=======
+Footnotes
+=========
 
-Add a footnote
+Footnotes use a mix of roles and directives
+
+First Footnotes
+---------------
 
 Lorem ipsum [#f1]_ dolor sit amet ... [#f2]_
 
@@ -10,6 +13,9 @@ Lorem ipsum [#f1]_ dolor sit amet ... [#f2]_
 .. [#f1] Text of the first footnote.
 .. [#f2] Text of the second footnote.
 
+Second Footnotes
+----------------
+
 Lorem ipsum [#]_ dolor sit amet ... [#]_
 
 .. rubric:: Footnotes
@@ -17,7 +23,10 @@ Lorem ipsum [#]_ dolor sit amet ... [#]_
 .. [#] Text of the first footnote.
 .. [#] Text of the second footnote.
 
-and example from lectures
+Third Footnotes
+---------------
+
+and example within a list
 
 Just as `NumPy <http://www.numpy.org/>`_ provides the basic array data type plus core array operations, pandas
 

--- a/tests/source/docutils/index.rst
+++ b/tests/source/docutils/index.rst
@@ -8,3 +8,4 @@ Docutils Tests
    elements
    directives
    roles
+   footnotes

--- a/tests/test_mystparser.py
+++ b/tests/test_mystparser.py
@@ -49,7 +49,7 @@ def test_docutils(
     get_sphinx_app_doctree(app, docname="elements", regress=True)
     get_sphinx_app_output(
         app,
-        files=["index.md", "elements.md", "directives.md", "roles.md"],
+        files=["index.md", "elements.md", "directives.md", "roles.md", "footnotes.md"],
         regress=True,
     )
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -24,6 +24,7 @@ maxdepth: 2
 elements
 directives
 roles
+footnotes
 ```
 
 
@@ -371,4 +372,51 @@ Since Pythagoras, we know that $a^2 + b^2 = c^2$.
 and math in a list:
 
 * this is $a^2 + b^2 = c^2$ in a list item
+
+
+------------
+footnotes.md
+------------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Footnotes
+
+Footnotes use a mix of roles and directives
+
+## First Footnotes
+
+Lorem ipsum [^f1] dolor sit amet ... [^f2]
+
+[^f1]: Text of the first footnote.
+
+[^f2]: Text of the second footnote.
+
+## Second Footnotes
+
+Lorem ipsum [^autoid_0] dolor sit amet ... [^autoid_1]
+
+[^autoid_0]: Text of the first footnote.
+
+[^autoid_1]: Text of the second footnote.
+
+## Third Footnotes
+
+and example within a list
+
+Just as [NumPy](http://www.numpy.org/) provides the basic array data type plus core array operations, pandas
+
+1. endows them with methods that facilitate operations such as
+    * sorting, grouping, re-ordering and general data munging [^mung]
+
+[^mung]: Wikipedia defines munging as cleaning data from one raw form into a structured, purged one.
 


### PR DESCRIPTION
This PR updates implementation for footnote references to `myst` syntax

It includes:

1. named footnotes
2. auto-numbered footnotes

https://jupyterbook.org/content/content-blocks.html?highlight=footnote#footnotes