### PR TITLE
[FIX] fix issue with parsing targets in documents

### DIFF
--- a/sphinxcontrib/tomyst/writers/translator.py
+++ b/sphinxcontrib/tomyst/writers/translator.py
@@ -89,7 +89,6 @@ class MystTranslator(SphinxTranslator):
     index = dict()
     index["in"] = False
     index["type"] = None
-    index["skip-target"] = False
     # Math
     math_block = dict()
     math_block["in"] = False
@@ -812,7 +811,6 @@ class MystTranslator(SphinxTranslator):
     def depart_index(self, node):
         self.index["in"] = False
         self.index["type"] = None
-        self.index["skip-target"] = True
 
     # docutils.elements.inline
     # uses: container?
@@ -1346,14 +1344,20 @@ file will be included in the myst directive".format(
     # https://docutils.sourceforge.io/docs/ref/doctree.html#target
 
     def visit_target(self, node):
-        if self.index["skip-target"]:
-            raise nodes.SkipNode
         if "refid" in node.attributes:
-            self.output.append(self.syntax.visit_target(node.attributes["refid"]))
-            self.add_newline()
+            targetname = node.attributes["refid"]
+        elif "refuri" in node.attributes:
+            # refuri handled in visit_reference
+            raise nodes.SkipNode
+        elif len(node.attributes["names"]) == 1:
+            targetname = node.attributes["names"][0]
+        else:
+            raise nodes.SkipNode
+        self.output.append(self.syntax.visit_target(targetname))
+        self.add_newline()
 
     def depart_target(self, node):
-        self.index["skip-target"] = False
+        pass
 
     # docutils.elements.tbody
     # uses: table

--- a/tests/source/docutils/elements.rst
+++ b/tests/source/docutils/elements.rst
@@ -19,6 +19,7 @@ Text
 
 This is some text
 
+.. _block_quote:
 
 block_quote
 -----------
@@ -109,3 +110,9 @@ The enumerated list from docutils
    (C) Item C.
 
 2. Item 2.
+
+
+target Links
+------------
+
+See :ref:`block quote section <block_quote>` above

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -52,6 +52,7 @@ are **not** directives.
 
 This is some text
 
+(block_quote)=
 ## block_quote
 
 This is the main document
@@ -122,6 +123,10 @@ The enumerated list from docutils
     1. Item B.
     1. Item C.
 1. Item 2.
+
+## target Links
+
+See {ref}`block quote section <block_quote>` above
 
 
 -------------
@@ -232,6 +237,7 @@ single: programming
 :name: reference-id
 ```
 
+(reference-id)=
 A point in the text you'd like to reference something
 about python
 

--- a/tests/test_mystparser/test_docutils.xml
+++ b/tests/test_mystparser/test_docutils.xml
@@ -64,7 +64,8 @@
                 Text
             <paragraph>
                 This is some text
-        <section ids="block-quote" names="block_quote">
+            <target refid="block-quote">
+        <section dupnames="block_quote" ids="block-quote id1" names="block_quote">
             <title>
                 block_quote
             <paragraph>
@@ -210,3 +211,12 @@
                 <list_item>
                     <paragraph>
                         Item 2.
+        <section ids="target-links" names="target\ links">
+            <title>
+                target Links
+            <paragraph>
+                See 
+                <pending_xref refdoc="elements" refdomain="std" refexplicit="True" reftarget="block_quote" reftype="ref" refwarn="True">
+                    <inline classes="xref std std-ref">
+                        block quote section
+                 above


### PR DESCRIPTION
This PR fixes an issue when parsing `targets` in documents. This supports the inclusion of

```rst
.. _targetname:
```

and will become

```md
(targetname)=
```